### PR TITLE
Automated Changelog Entry for 1.0.0 on 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.0.0
+
+([Full Changelog](https://github.com/team-monolith-product/jupyterlab-reset-fixer/compare/v0.0.1...789fe236d46fc7dad6ab7e94ed6f94146902cdc6))
+
+### Merged PRs
+
+- feat: update to jupyter lab 4 [#2](https://github.com/team-monolith-product/jupyterlab-reset-fixer/pull/2) ([@a3626a](https://github.com/a3626a))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/team-monolith-product/jupyterlab-reset-fixer/graphs/contributors?from=2022-07-05&to=2022-10-08&type=c))
+
+[@a3626a](https://github.com/search?q=repo%3Ateam-monolith-product%2Fjupyterlab-reset-fixer+involves%3Aa3626a+updated%3A2022-07-05..2022-10-08&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.0.1
 
 No merged PRs
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 1.0.0 on 1.0

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/team-monolith-product/jupyterlab-reset-fixer/releases/tag/untagged-cbf61d9fbdfdfa576b2f  |
| Since | v0.0.1 |